### PR TITLE
Seperating build for server and app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,7 @@ jobs:
         with:
           go-version: '1.24.3'
 
-      - name: Build Go backend
+      - name: Build Go backend - desktop app and server
         working-directory: backend
         run: |
           export GOOS=${{ matrix.os }}


### PR DESCRIPTION
Seperating build for server and app
Because the app needs gtk, webkit and other libraries, when using the same binary everywhere those desktop ui libraries are also expected to be installed in the server also