### PR TITLE
Stop streaming assistant response

### DIFF
--- a/backend/chatservice/service/service.go
+++ b/backend/chatservice/service/service.go
@@ -189,7 +189,6 @@ func (s *ChatService) Chat(ctx context.Context, userID string, req *pb.ChatReque
 	var requestMessageId string
 	var referencesJSON string
 	if len(ragChunks) > 0 {
-		// Create the RAG JSON structure from chunks
 		ragDocuments := s.createRAGDocumentJSONFromChunks(ragChunks)
 		referencesBytes, err := json.Marshal(ragDocuments)
 		if err != nil {
@@ -226,7 +225,7 @@ func (s *ChatService) Chat(ctx context.Context, userID string, req *pb.ChatReque
 		return fmt.Errorf("failed to marshal request: %v", err)
 	}
 
-	httpReq, err := http.NewRequest("POST", s.settingsManager.GetSettings().OpenAIAPIURL, bytes.NewBuffer(jsonData))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", s.settingsManager.GetSettings().OpenAIAPIURL, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %v", err)
 	}
@@ -247,8 +246,31 @@ func (s *ChatService) Chat(ctx context.Context, userID string, req *pb.ChatReque
 	var fullResponse strings.Builder
 	var inputTokens, outputTokens, cachedTokens int
 
-	// Streaming response from LLM API
 	scanner := bufio.NewScanner(resp.Body)
+
+	// Function to save partial response
+	savePartialResponse := func() {
+		assistantText := fullResponse.String()
+		if assistantText != "" {
+			var partialReferencesJSON string
+			if len(ragChunks) > 0 {
+				partialRagDocs := s.createRAGDocumentJSONFromChunks(ragChunks)
+				partialRefsBytes, err := json.Marshal(partialRagDocs)
+				if err != nil {
+					slog.Error("failed to marshal RAG document references for partial response", "error", err)
+				} else {
+					partialReferencesJSON = string(partialRefsBytes)
+				}
+			}
+			_, err := s.dao.AddChatMessageWithTokens(userID, chatId, "assistant", assistantText, model, inputTokens, outputTokens, cachedTokens, partialReferencesJSON, ragEnabled)
+			if err != nil {
+				slog.Error("failed to save partial assistant message", "error", err)
+			} else {
+				slog.Info("saved partial response to database", "length", len(assistantText))
+			}
+		}
+	}
+
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 
@@ -299,37 +321,40 @@ func (s *ChatService) Chat(ctx context.Context, userID string, req *pb.ChatReque
 		if delta, ok := choice["delta"].(map[string]interface{}); ok {
 			if content, ok := delta["content"].(string); ok && content != "" {
 				fullResponse.WriteString(content)
-
-				if err := stream(&pb.ChatResponse{Response: &pb.ChatResponse_Text{
-					Text: content,
-				}}); err != nil {
+				if err := stream(&pb.ChatResponse{Response: &pb.ChatResponse_Text{Text: content}}); err != nil {
+					// If streaming fails, save partial response before returning error
+					slog.Error("failed to send stream response, saving partial response", "error", err)
+					savePartialResponse()
 					return fmt.Errorf("failed to send stream response: %v", err)
 				}
 			}
 		}
 	}
-
 	if err := scanner.Err(); err != nil {
+		if ctx.Err() != nil {
+			slog.Info("streaming cancelled by client, saving partial response")
+		} else {
+			slog.Error("scanner error occurred, saving partial response", "error", err)
+		}
+		savePartialResponse() //save partial response
 		return fmt.Errorf("error reading stream: %v", err)
 	}
 
+	// Normal completion - save full response
 	assistantText := fullResponse.String()
 	if assistantText != "" {
-		var referencesJSON string
+		var finalReferencesJSON string
 		if len(ragChunks) > 0 {
-			// Create the new JSON structure as requested
-			ragDocuments := s.createRAGDocumentJSONFromChunks(ragChunks)
-			referencesBytes, err := json.Marshal(ragDocuments)
+			finalRagDocs := s.createRAGDocumentJSONFromChunks(ragChunks)
+			finalRefsBytes, err := json.Marshal(finalRagDocs)
 			if err != nil {
 				slog.Error("failed to marshal RAG document references", "error", err)
 			} else {
-				referencesJSON = string(referencesBytes)
+				finalReferencesJSON = string(finalRefsBytes)
 			}
 		}
-
-		// TODO: we dont save streaming response, if stream is killed we loose the message.
 		// TODO : scope for optimization, can be 1 sql call internally
-		daoSummary, err := s.dao.AddChatMessageWithTokens(userID, chatId, "assistant", assistantText, model, inputTokens, outputTokens, cachedTokens, referencesJSON, ragEnabled)
+		daoSummary, err := s.dao.AddChatMessageWithTokens(userID, chatId, "assistant", assistantText, model, inputTokens, outputTokens, cachedTokens, finalReferencesJSON, ragEnabled)
 		if err != nil {
 			log.Printf("Failed to insert assistant message: %v", err)
 		} else {
@@ -341,11 +366,7 @@ func (s *ChatService) Chat(ctx context.Context, userID string, req *pb.ChatReque
 				CachedTokens: int32(daoSummary.CachedTokenCount),
 				Cost:         float32(daoSummary.Cost),
 			}
-			if err := stream(&pb.ChatResponse{
-				Response: &pb.ChatResponse_Summary{
-					Summary: pbSummary,
-				},
-			}); err != nil {
+			if err := stream(&pb.ChatResponse{Response: &pb.ChatResponse_Summary{Summary: pbSummary}}); err != nil {
 				return fmt.Errorf("failed to send message summary: %v", err)
 			}
 		}

--- a/frontend/src/pages/chat.tsx
+++ b/frontend/src/pages/chat.tsx
@@ -1,4 +1,3 @@
-
 import { Button } from "@/components/ui/button";
 import { ChatInput } from "@/components/ui/chat/chat-input";
 import {
@@ -14,7 +13,8 @@ import {
   ArrowUp,
   ArrowDown,
   DollarSign,
-  ChevronRight
+  ChevronRight,
+  Square // Add Square icon for stop button
 } from "lucide-react";
 import React, { useEffect, useRef, useState } from "react";
 import { useStore } from "@nanostores/react";
@@ -38,6 +38,8 @@ import {
   $chatMetadata,
   $responseSummaries,
   $currentAssistantMessageId,
+  stream,
+  $isStreaming,
 } from "@/store/chat";
 import { EnhancedMarkdown } from "@/components/enhanced-markdown";
 import {
@@ -327,19 +329,28 @@ function ChatInputBox({
   const selectedModel = useStore($selectedModel);
   const ragEnabled = useStore($ragEnabled);
   const chatMetadata = useStore($chatMetadata);
+  const isStreaming = useStore($isStreaming);
 
   const handleSend = () => {
-    if (inputValue.trim()) {
+    if (inputValue.trim() && !isStreaming) {
       onSendMessage(inputValue);
       setInputValue("");
     }
   };
 
+  const handleStop = () => {
+    $isStreaming.set(false);
+    if (stream) {
+      stream.cancel();
+    }
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    // Avoid sending while the user is composing text (IME)
+    // Avoid sending while the user is composing text (IME) or while streaming
     if (
       e.key === "Enter" &&
       !e.shiftKey &&
+      !isStreaming &&
       !(e.nativeEvent?.isComposing || (e as any).isComposing)
     ) {
       e.preventDefault();
@@ -368,6 +379,7 @@ function ChatInputBox({
                 checked={ragEnabled}
                 onChange={toggleRagEnabled}
                 className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                disabled={isStreaming} // Disable during streaming
               />
               <span>Enable RAG (Retrieval-Augmented Generation)</span>
             </label>
@@ -376,16 +388,21 @@ function ChatInputBox({
 
         <div className="relative rounded-lg border border-gray-300 bg-white focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-blue-500">
           <ChatInput
-            placeholder="Ask anything"
+            placeholder={isStreaming ? "Response is being generated..." : "Ask anything"}
             className="min-h-12 resize-none rounded-lg bg-transparent border-0 p-3 shadow-none focus-visible:ring-0"
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
             onKeyDown={handleKeyDown}
+            disabled={isStreaming} // Disable input during streaming
           />
           <div className="flex items-center justify-between p-3 pt-0">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="outline" size="sm" className="text-xs">
+                <Button 
+                  variant="outline" 
+                  size="sm" 
+                  className="text-xs"
+                >
                   {selectedModel || "Select Model"}
                 </Button>
               </DropdownMenuTrigger>
@@ -400,14 +417,27 @@ function ChatInputBox({
                 ))}
               </DropdownMenuContent>
             </DropdownMenu>
-            <Button
-              size="sm"
-              className="bg-black hover:bg-gray-800 text-white px-4"
-              onClick={handleSend}
-              disabled={!inputValue.trim()}
-            >
-              <CornerDownLeft className="size-3.5" />
-            </Button>
+            
+            {isStreaming ? (
+              <Button
+                size="sm"
+                variant="destructive"
+                className="px-4"
+                onClick={handleStop}
+                title="Stop Streaming"
+              >
+                <Square className="size-3.5" />
+              </Button>
+            ) : (
+              <Button
+                size="sm"
+                className="bg-black hover:bg-gray-800 text-white px-4"
+                onClick={handleSend}
+                disabled={!inputValue.trim()}
+              >
+                <CornerDownLeft className="size-3.5" />
+              </Button>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/store/chat.ts
+++ b/frontend/src/store/chat.ts
@@ -34,6 +34,7 @@ import {
 } from "../../proto/chatservice";
 import { atom, onMount } from "nanostores";
 import { createAuthenticatedClientOptions } from "../lib/auth";
+import type { ClientReadableStream } from "grpc-web";
 
 // Create chat client with JWT authentication
 var chat = new SortedChatClient(
@@ -191,7 +192,8 @@ const isFirstMessageInChat = (): boolean => {
 
 export const $chatMetadata = atom<ChatInfo | null>(null);
 
-
+export let stream: ClientReadableStream<ChatResponse> | null = null;
+export let $isStreaming = atom<boolean>(false);
 export const doChat = (msg: string,projectId: string | undefined) => {
   $currentChatMessage.set(msg);
   $streamingMessage.set("");
@@ -222,7 +224,7 @@ export const doChat = (msg: string,projectId: string | undefined) => {
   }
 
   // grpc call
-  const stream = chat.Chat(
+   stream = chat.Chat(
     ChatRequest.fromObject({
       text: msg,
       chatId: $currentChatId.get(),
@@ -239,6 +241,7 @@ export const doChat = (msg: string,projectId: string | undefined) => {
     if (res.has_text) {
       assistantResponse += res.text;
       $streamingMessage.set(assistantResponse);
+      $isStreaming.set(true);
     } else if (res.has_request_message_id) {
       $currentUserMessageId.set(res.request_message_id); //(user) message id is set in the store
     } else if (res.has_summary) {
@@ -295,6 +298,8 @@ export const doChat = (msg: string,projectId: string | undefined) => {
     addMessageToHistory(userMessage);
     addMessageToHistory(assistantMessage);
 
+    $isStreaming.set(false);
+
     $streamingMessage.set("");
     $currentChatMessage.set("");
     
@@ -315,7 +320,7 @@ export const doChat = (msg: string,projectId: string | undefined) => {
     console.error("Stream error:", err);
     $streamingMessage.set("");
     toast.error("An error occurred while receiving the response. Please try again.");  
-
+    $isStreaming.set(false);
     
     // Reset RAG to enabled for project chats even on error
     if (projectId) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Stop Streaming control to halt AI responses mid-generation.
  - Chat input, send action, and RAG toggle now respect streaming state (disabled while generating).
- Improvements
  - Dynamic placeholder indicates when a response is being generated.
  - Enter-to-send and IME handling adjusted to prevent accidental sends during streaming.
  - Consistent button styling for model selection.
  - More reliable partial response saving if streaming is interrupted, reducing lost progress.
- Bug Fixes
  - Streaming state now correctly resets on completion or error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->