### PR TITLE
Fix: use standalone build for web app binary instead of production build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,7 +234,7 @@ jobs:
           fi
 
           go env
-          go build -buildvcs=false -tags "desktop,sqlite_fts5,webkit2_41,wv2runtime.download,devtools" -ldflags "-w -s" -o $BINARY_NAME_SERVER ./mono
+          go build -buildvcs=false -tags "prod,desktop,sqlite_fts5,webkit2_41,wv2runtime.download,production,devtools" -ldflags "-w -s" -o $BINARY_NAME_SERVER ./mono
           go build -buildvcs=false -tags "prod,wails,desktop,sqlite_fts5,webkit2_41,wv2runtime.download,production,devtools" -ldflags "-w -s" -o $BINARY_NAME_APP ./mono
 
       - name: Upload server binary as artifact


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to use a "standalone" frontend artifact name and simplify artifact handling.
  * Replaced a dedicated artifact download step with a direct copy of built frontend files into the Wails build path.
  * Minor workflow formatting cleanups.

No user-facing changes; internal build and workflow maintenance only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->