### PR TITLE
Add Panic Interceptor in gRPC Server

### DIFF
--- a/backend/common/panic/panic_interceptor.go
+++ b/backend/common/panic/panic_interceptor.go
@@ -3,7 +3,7 @@ package panic
 import (
 	"context"
 	"log/slog"
-	"runtime"
+	"runtime/debug"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -35,12 +35,9 @@ func StreamInterceptor() grpc.StreamServerInterceptor {
 	}
 }
 
-func panicRecoveryHandler(p interface{}, info string) error {
-	stack := make([]byte, 4096)
-	length := runtime.Stack(stack, false)
-	slog.Error("panic recovered in stream RPC",
+func panicRecoveryHandler(p interface{}, info string) {
+	slog.Error("panic recovered in gRPC handler",
 		"method", info,
 		"panic", p,
-		"stack", string(stack[:length]))
-	return status.Errorf(codes.Internal, "internal server error")
+		"stack", string(debug.Stack()))
 }

--- a/backend/mono/main.go
+++ b/backend/mono/main.go
@@ -161,8 +161,8 @@ func main() {
 	// this does not work when services are on multiple server.
 	// at that time we need to make a deision : either pass api level authentication (jwt) to the other service or use mtls or some other microservice communication auth
 	internalGrpcServer := grpc.NewServer(
-		grpc.UnaryInterceptor(panicInterceptor.UnaryInterceptor()),
-		grpc.StreamInterceptor(panicInterceptor.StreamInterceptor()),
+		grpc.ChainUnaryInterceptor(panicInterceptor.UnaryInterceptor()),
+		grpc.ChainStreamInterceptor(panicInterceptor.StreamInterceptor()),
 	)
 
 	// Create HTTP auth middleware


### PR DESCRIPTION
closes #237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server stability by adding panic protection for RPC handlers so unexpected failures are captured, logged with context and stack traces, and returned as standardized internal errors to avoid crashes and aid diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->