### PR TITLE
Disable Realtime Audio Chat on Linux Desktop

### DIFF
--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -73,13 +73,8 @@ export function AppSidebar() {
 
   useEffect(() => {
     const checkEnv = async () => {
-      // Check if running in Wails
       if (typeof window !== 'undefined' && ((window as any).runtime || (window as any).go)) {
         try {
-          // Dynamic import to avoid build issues if wailsjs is not present in some environments
-          // or just import it at top level if we are sure. 
-          // Since we are in the same repo, we can import it.
-          // But wait, I need to add the import at the top.
           const { Environment } = await import("../../wailsjs/runtime/runtime");
           const env = await Environment();
           if (env.platform === 'linux') {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detects Linux Desktop at runtime and disables the New Realtime Voice Chat action on that platform.
  * Action button now only opens the audio modal when not on Linux Desktop; on Linux it’s visually disabled with reduced opacity, a disabled cursor, and a “Not available on Linux Desktop.” tooltip.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->