### PR TITLE
Add toast notification for successful API key save

### DIFF
--- a/frontend/src/components/providers/claude-provider.tsx
+++ b/frontend/src/components/providers/claude-provider.tsx
@@ -3,9 +3,10 @@ import { ProviderView } from './provider-view';
 interface ClaudeProviderProps {
     onApiKeyChange?: (key: string) => void;
     onApiUrlChange?: (url: string) => void;
+    onSaveSuccess?: () => void;
 }
 
-export const ClaudeProvider = ({ onApiKeyChange, onApiUrlChange }: ClaudeProviderProps) => {
+export const ClaudeProvider = ({ onApiKeyChange, onApiUrlChange, onSaveSuccess }: ClaudeProviderProps) => {
     return (
         <ProviderView
             providerName="claude"
@@ -13,6 +14,7 @@ export const ClaudeProvider = ({ onApiKeyChange, onApiUrlChange }: ClaudeProvide
             defaultApiUrl="https://api.anthropic.com/v1/messages"
             onApiKeyChange={onApiKeyChange}
             onApiUrlChange={onApiUrlChange}
+            onSaveSuccess={onSaveSuccess}
         />
     );
 };

--- a/frontend/src/components/providers/gemini-provider.tsx
+++ b/frontend/src/components/providers/gemini-provider.tsx
@@ -3,9 +3,10 @@ import { ProviderView } from './provider-view';
 interface GeminiProviderProps {
     onApiKeyChange?: (key: string) => void;
     onApiUrlChange?: (url: string) => void;
+    onSaveSuccess?: () => void;
 }
 
-export const GeminiProvider = ({ onApiKeyChange, onApiUrlChange }: GeminiProviderProps) => {
+export const GeminiProvider = ({ onApiKeyChange, onApiUrlChange, onSaveSuccess }: GeminiProviderProps) => {
     return (
         <ProviderView
             providerName="gemini"
@@ -13,6 +14,7 @@ export const GeminiProvider = ({ onApiKeyChange, onApiUrlChange }: GeminiProvide
             defaultApiUrl="https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
             onApiKeyChange={onApiKeyChange}
             onApiUrlChange={onApiUrlChange}
+            onSaveSuccess={onSaveSuccess}
         />
     );
 };

--- a/frontend/src/components/providers/openai-provider.tsx
+++ b/frontend/src/components/providers/openai-provider.tsx
@@ -3,9 +3,10 @@ import { ProviderView } from './provider-view';
 interface OpenaiProviderProps {
     onApiKeyChange?: (key: string) => void;
     onApiUrlChange?: (url: string) => void;
+    onSaveSuccess?: () => void;
 }
 
-export const OpenaiProvider = ({ onApiKeyChange, onApiUrlChange }: OpenaiProviderProps) => {
+export const OpenaiProvider = ({ onApiKeyChange, onApiUrlChange, onSaveSuccess }: OpenaiProviderProps) => {
     return (
         <ProviderView
             providerName="openai"
@@ -13,6 +14,7 @@ export const OpenaiProvider = ({ onApiKeyChange, onApiUrlChange }: OpenaiProvide
             defaultApiUrl="https://api.openai.com/v1/chat/completions"
             onApiKeyChange={onApiKeyChange}
             onApiUrlChange={onApiUrlChange}
+            onSaveSuccess={onSaveSuccess}
         />
     );
 };

--- a/frontend/src/components/providers/provider-view.tsx
+++ b/frontend/src/components/providers/provider-view.tsx
@@ -1,5 +1,6 @@
 import { useStore } from '@nanostores/react';
 import { useState, useEffect } from 'react';
+import { toast } from 'sonner';
 import {
     $modelsByProvider,
     $isLoadingModels,
@@ -19,6 +20,7 @@ interface ProviderViewProps {
     defaultApiUrl?: string;
     onApiKeyChange?: (key: string) => void;
     onApiUrlChange?: (url: string) => void;
+    onSaveSuccess?: () => void;
     compact?: boolean;
 }
 
@@ -28,6 +30,7 @@ export const ProviderView = ({
     defaultApiUrl = '',
     onApiKeyChange,
     onApiUrlChange,
+    onSaveSuccess,
     compact = false
 }: ProviderViewProps) => {
     const modelsByProvider = useStore($modelsByProvider);
@@ -71,8 +74,14 @@ export const ProviderView = ({
             });
 
             await SetProviderSetting(providerName, settings);
+            if (onSaveSuccess) {
+                onSaveSuccess();
+            } else {
+                toast.success('API key has been successfully saved');
+            }
         } catch (error) {
             console.error('Failed to save provider settings:', error);
+            toast.error('Failed to save API key');
         } finally {
             setIsSaving(false);
         }

--- a/frontend/src/pages/models.tsx
+++ b/frontend/src/pages/models.tsx
@@ -1,6 +1,7 @@
 
 import { useStore } from '@nanostores/react';
 import { useState, useEffect } from 'react';
+import { toast } from 'sonner';
 import {
   $llmModels,
   ListLLMModels,
@@ -25,6 +26,11 @@ const Models = () => {
   const isLoadingProviders = useStore($isLoadingProviderSettings);
 
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
+
+  // Handler for successful API key save
+  const handleApiKeySaveSuccess = () => {
+    toast.success('API key has been successfully saved');
+  };
 
   // Load data on mount
   useEffect(() => {
@@ -62,15 +68,15 @@ const Models = () => {
 
     switch (selectedProvider) {
       case 'openai':
-        return <OpenaiProvider />;
+        return <OpenaiProvider onSaveSuccess={handleApiKeySaveSuccess} />;
       case 'claude':
-        return <ClaudeProvider />;
+        return <ClaudeProvider onSaveSuccess={handleApiKeySaveSuccess} />;
       case 'gemini':
-        return <GeminiProvider />;
+        return <GeminiProvider onSaveSuccess={handleApiKeySaveSuccess} />;
       case 'local':
         return <LocalProvider />;
       default:
-        return <ProviderView providerName={selectedProvider} />;
+        return <ProviderView providerName={selectedProvider} onSaveSuccess={handleApiKeySaveSuccess} />;
     }
   };
 


### PR DESCRIPTION
This PR adds a toast notification that appears after users successfully save their API key for cloud providers (OpenAI, Gemini, Claude).

## Changes
- Added toast import and handler function in `models.tsx`
- Added `onSaveSuccess` callback prop to provider components (OpenaiProvider, ClaudeProvider, GeminiProvider)
- Updated `ProviderView` to accept and call the `onSaveSuccess` callback
- Toast message: 'API key has been successfully saved'

## Testing
- Save API keys for OpenAI, Claude, and Gemini providers
- Verify that success toast appears after successful save

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added success and error notifications when saving API provider settings, providing users with immediate feedback on whether their configuration was saved successfully or encountered an error.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->