### PR TITLE
Update copyright year to 2026 in login page

### DIFF
--- a/frontend/src/auth/pages/login.tsx
+++ b/frontend/src/auth/pages/login.tsx
@@ -153,7 +153,7 @@ export function LoginPage() {
 
         {/* Footer */}
         <div className="text-center text-xs text-gray-400">
-          <p>© 2024 SortedChat. All rights reserved.</p>
+          <p>© 2026 SortedChat. All rights reserved.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Updated the copyright year from 2024 to 2026 in the login page located at frontend/src/auth/pages/login.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year in the footer.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->